### PR TITLE
Mandatsträger aus BW hinzufügen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Hier finden sich Informationen über die kommunalen Mandatsträger der Piratenpartei Deutschland.
 
-* JSON mit den bekannten Mandatsträgern der Partei.
+* (JSON mit den bekannten Mandatsträgern der Partei)[v1/kommunalpiraten.json].
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Hier finden sich Informationen über die kommunalen Mandatsträger der Piratenpartei Deutschland.
 
-* (JSON mit den bekannten Mandatsträgern der Partei)[v1/kommunalpiraten.json].
+* [JSON mit den bekannten Mandatsträgern der Partei](v1/kommunalpiraten.json)
 

--- a/v1/README.md
+++ b/v1/README.md
@@ -1,4 +1,4 @@
-# JSON File mit dne Kommunalpiraten der Piratenpartei Deutschland
+# JSON File mit den Kommunalpiraten der Piratenpartei Deutschland
 
 Die JSON-Datei enthält die Liste der bekannten Mitglieder der Piratenpartei in kommunalen Mandaten per Stand vom 9. August 2022.
 

--- a/v1/kommunalpiraten.json
+++ b/v1/kommunalpiraten.json
@@ -87,5 +87,148 @@
         "bis": 2021,
         "Webseite": "",
         "aktiv": false
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Anja",
+        "Nachname": "Hirschel",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Ulm",
+        "Ort": "Ulm",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Sabine",  
+        "Nachname": "Schuhmacher",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Lörrach",
+        "Ort": "Lörrach",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Michael",  
+        "Nachname": "Freche",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Göppingen",
+        "Ort": "Göppingen",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Julia",  
+        "Nachname": "Uebele",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Göppingen",
+        "Ort": "Göppingen",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Annette",  
+        "Nachname": "Linder",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Gutach im Breisgau",
+        "Ort": "Gutach im Breisgau",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Philip",  
+        "Nachname": "Köngeter",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Welzheim",
+        "Ort": "Welzheim",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Kai",  
+        "Nachname": "Dorra",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Welzheim",
+        "Ort": "Welzheim",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Philip",  
+        "Nachname": "Köngeter",
+        "Gebietskörperschaft": "Kreis",
+        "Name des Parlaments": "Kreistag Rems-Murr",
+        "Ort": "Rems-Murr",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Stefan",  
+        "Nachname": "Urbat",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Stadtrat Stuttgart",
+        "Ort": "Stuttgart",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Michael",  
+        "Nachname": "Knödler",
+        "Gebietskörperschaft": "Region",
+        "Name des Parlaments": "Regionalrat Stuttgart",
+        "Ort": "Stuttgart",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Volker",  
+        "Nachname": "Dyken",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Backnang",
+        "Ort": "Backnang",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Manuel",  
+        "Nachname": "Feuersänger",
+        "Gebietskörperschaft": "Stadt",
+        "Name des Parlaments": "Gemeinderat Täferrot",
+        "Ort": "Täferrot",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
+        }, {
+        "Bundesland": "Baden-Württemberg",
+        "Vorname": "Sabine",  
+        "Nachname": "Schuhmacher",
+        "Gebietskörperschaft": "Kreis",
+        "Name des Parlaments": "Kreistag Lörrach",
+        "Ort": "Lörrach",
+        "seit": 2019,
+        "bis": null,
+        "Webseite": "-/-",
+        "aktiv": true
         }]
 }


### PR DESCRIPTION
PR enthält die Mandatsträger aus Baden-Württemberg und ein paar kleinere Schönheitsreparaturen.